### PR TITLE
GSheet 기능 개선(9/14)

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -44,6 +44,7 @@ class Logic(object):
         'copy_delay':'30',
         'copy_count_limit':'1',
         'copy_mode':'0',
+        'plex_condition':'0',   # 미사용
     }
 
     @staticmethod
@@ -125,6 +126,7 @@ class Logic(object):
     @staticmethod
     def migration():
         LogicGSheet.ws_ir_init()
+        LogicGSheet.google_api_auth()
         # TEMP CODE
         try:
             # for temporary: ListModelItem Table alter
@@ -144,12 +146,14 @@ class Logic(object):
             alter_byte_size = True
             alter_updated_time = True
             alter_excluded = True
+            alter_mimetype = True
             for row in cur.execute(q).fetchall():
                 if row[1] == 'byte_size': alter_byte_size = False
                 if row[1] == 'updated_time': alter_updated_time = False
                 if row[1] == 'excluded': alter_excluded = False
+                if row[1] == 'mimetype': alter_mimetype = False
 
-            if alter_byte_size is False and alter_updated_time is False and alter_excluded is False:
+            if alter_byte_size is False and alter_updated_time is False and alter_excluded is False and alter_mimetype is False:
                 conn.close()
                 return
 
@@ -165,6 +169,10 @@ class Logic(object):
                 query = 'ALTER TABLE {table_name} ADD COLUMN excluded INTEGER default 0'.format(table_name=table_name)
                 cur.execute(query)
                 logger.info('LiteModelItem Alterred(column: excluded)')
+            if alter_mimetype:
+                query = 'ALTER TABLE {table_name} ADD COLUMN mimetype INTEGER default 0'.format(table_name=table_name)
+                cur.execute(query)
+                logger.info('LiteModelItem Alterred(column: mimetype)')
             conn.commit()
             conn.close()
         except Exception as e: 

--- a/templates/rclone_expand_gsheet_item_list.html
+++ b/templates/rclone_expand_gsheet_item_list.html
@@ -45,7 +45,7 @@
   {{ macros.m_row_start('0') }}
   {{ macros.m_col(2, macros.m_strong('ID/생성/갱신시각')) }}
   {{ macros.m_col(4, macros.m_strong('제목/매핑제목')) }}
-  {{ macros.m_col(2, macros.m_strong('폴더ID')) }}
+  {{ macros.m_col(2, macros.m_strong('유형/ID')) }}
   {{ macros.m_col(2, macros.m_strong('정보')) }}
   {{ macros.m_col(2, macros.m_strong('복사')) }}
   {{ macros.m_row_end() }}
@@ -125,7 +125,13 @@ function make_list(data) {
     str += m_col(2, tmp);
     tmp = data[i].title + '<br>' + data[i].title2;
     str += m_col(4, tmp);
-    tmp = '<a href="https://drive.google.com/drive/folders/' +data[i].folder_id+ '" target="_blank">';
+    if (data[i].mimetype == 0) {
+      tmp = '폴더<br>';
+      tmp += '<a href="https://drive.google.com/drive/folders/' +data[i].folder_id+ '" target="_blank">';
+    } else {
+      tmp = '파일<br>';
+      tmp += '<a href="https://drive.google.com/file/d/' +data[i].folder_id+ '" target="_blank">';
+    }
     tmp += data[i].folder_id+ '</a>';
     str += m_col(2, tmp);
     tmp = '<strong>'+data[i].category+'</strong>';

--- a/templates/rclone_expand_gsheet_list.html
+++ b/templates/rclone_expand_gsheet_list.html
@@ -79,7 +79,7 @@
     {{ macros.info_text('ws_title', '시트제목') }}
     {{ macros.info_text('ws_stat', '복사/자료건수') }}
     {{ macros.setting_checkbox('ws_in_schedule', '스케쥴링에 포함', desc=['On: 스케쥴링 동작시 문서 갱신 및 자동복사.']) }}
-    {{ macros.setting_button([['ws_save_btn', '저장'], ['ws_delete_btn', '삭제']]) }}
+    {{ macros.setting_button([['ws_save_btn', '저장'], ['ws_delete_btn', '삭제'], ['ws_delete_items_btn', '아이템삭제']]) }}
   </form>
   <hr>
 {{ macros.m_modal_end() }}
@@ -321,7 +321,6 @@ $("body").on('click', '#load_item_btn', function(e){
     success: function (data) {
       if (data.ret) {
         $.notify('<strong>' + data.data + '</strong>', {type: 'success'});
-      	setTimeout(function(){location.reload();}, 2000);
       } else {
         $.notify('<strong>' + data.data + '</strong>', {type: 'warning'});
       }
@@ -371,6 +370,29 @@ $('#ws_detail_modal').on('click', '#ws_delete_btn', function (e) {
         $.notify('<strong>삭제하였습니다.</strong>', {type: 'success'});
       } else {
         $.notify('<strong>삭제실패</strong>', {type: 'warning'});
+      }
+      $("#ws_detail_modal").modal('hide');
+      request_search(current_page);
+    }
+  });
+})
+
+
+
+$('#ws_detail_modal').on('click', '#ws_delete_items_btn', function (e) {
+  e.preventDefault();
+  var formData = get_formdata('#ws_detail');
+  $.ajax({
+    url: '/' + package_name + '/ajax/'+sub+'/delete_items',
+    type: "POST", 
+    cache: false,
+    data: formData,
+    dataType: "json",
+    success: function (data) {
+      if (data.ret) {
+        $.notify('<strong>' + data.data + '</strong>', {type: 'success'});
+      } else {
+        $.notify('<strong>' + data.data + '</strong>', {type: 'warning'});
       }
       $("#ws_detail_modal").modal('hide');
       request_search(current_page);

--- a/templates/rclone_expand_gsheet_setting.html
+++ b/templates/rclone_expand_gsheet_setting.html
@@ -25,22 +25,25 @@
     {{ macros.setting_checkbox('copy_delay_use', '복사지연시간사용', value=arg['copy_delay_use'], desc=['복사 지연시간 사용여부', 'On: 사용, Off: 사용안함']) }}
     {{ macros.setting_input_int('copy_delay', '복사지연시간', value=arg['copy_delay'], min='0', placeholder='0', desc='minute 단위, 갱신시간 기준, 지연시간동안 갱신시각에 변경사항이 없는 경우 복사시도') }}
     {{ macros.setting_input_int('copy_count_limit', '복사횟수제한', value=arg['copy_count_limit'], min='1', placeholder='1', desc=['스케쥴링에 의한 복사시도 횟수, 0 인 경우 스케쥴링때마다 복사 시도', '2이상 설정하는 경우 "--ignore-existing" 옵션설정']) }}
-    {{ macros.setting_radio('copy_mode', '다운로드 모드', ['Nothing', '화이트리스트', '블랙리스트'], value=arg['copy_mode']) }}
+    <!--{{ macros.setting_radio('plex_condition', 'Plex연동모드', ['연동안함', '연동(없는경우만복사)', '연동(더큰용량의경우복사)'], desc=['Plex정보가 설정되어있어야 함.'], value=arg['plex_condition']) }} //-->
+    {{ macros.setting_radio('copy_mode', '복사모드', ['Nothing', '포함우선', '제외우선'], value=arg['copy_mode']) }}
     <div id="whitelist_div" class="collapse">
-    {{ macros.setting_input_textarea('category_rules', '자동다운조건-분류', desc=['분류명, 비어있는 경우 검사하지 않음', '여러조건 입력시 구분자는 Enter'], value=arg['category_rules'], row='3') }}
-    <!-- {{ macros.setting_input_textarea('keyword_rules', '자동다운조건-키워드', desc=['파일명기준 키워드, 비어있는 경우 검사하지 않음', '설정시 속도저하 있음, 여러조건 입력시 구분자는 |'], value=arg['keyword_rules'], row='1') }} //-->
+    {{ macros.setting_input_textarea('category_rules', '복사조건-포함분류', desc=['분류명, 비어있는 경우 검사하지 않음', '하위분류에 *지원, 예) 영화/*', '여러조건 입력시 구분자는 Enter'], value=arg['category_rules'], row='3') }}
+    {{ macros.setting_input_textarea('except_category_rules', '복사조건-제외분류', desc=['자동다운로드시 제외할 분류명','하위분류에 * 지원','분류명, 비어있는 경우 검사하지 않음', '여러조건 입력시 구분자는 Enter'], value=arg['except_category_rules'], row='3') }}
+    {{ macros.setting_input_textarea('keyword_rules', '복사조건-포함키워드', desc=['파일명기준 키워드, 비어있는 경우 검사하지 않음', '파일유형의 아이템에만 적용됨, 여러조건 입력시 구분자는 |'], value=arg['keyword_rules'], row='1') }}
     </div> 
     <div id="blacklist_div" class="collapse">
-    {{ macros.setting_input_textarea('except_category_rules', '자동다운-제외분류', desc=['자동다운로드시 제외할 분류명','분류명, 비어있는 경우 검사하지 않음', '여러조건 입력시 구분자는 Enter'], value=arg['except_category_rules'], row='3') }}
-    <!--{{ macros.setting_input_textarea('except_keyword_rules', '자동다운조건-제외키워드', desc=['파일명기준 키워드, 비어있는 경우 검사하지 않음', '설정시 속도저하 있음, 여러조건 입력시 구분자는 |'], value=arg['except_keyword_rules'], row='1') }} //-->
+    {{ macros.setting_input_textarea('except_category_rules', '복사조건-제외분류', desc=['자동다운로드시 제외할 분류명','분류명, 비어있는 경우 검사하지 않음', '여러조건 입력시 구분자는 Enter'], value=arg['except_category_rules'], row='3') }}
+    {{ macros.setting_input_textarea('category_rules', '복사조건-포함분류', desc=['분류명, 비어있는 경우 검사하지 않음', '하위분류에 *지원, 예) 영화/*', '여러조건 입력시 구분자는 Enter'], value=arg['category_rules'], row='3') }}
+    {{ macros.setting_input_textarea('except_keyword_rules', '복사조건-제외키워드', desc=['파일명기준 키워드, 비어있는 경우 검사하지 않음', '파일유형의 아이템에만 적용됨, 여러조건 입력시 구분자는 |'], value=arg['except_keyword_rules'], row='1') }}
     </div>
    {{ macros.m_tab_content_end() }}
    {{ macros.m_tab_content_start('action', false) }}
       {{ macros.setting_button([['all_reset_db_btn','전체삭제']], left='전체삭제', desc='등록된 모든 워크시트와 아이템목록을 삭제합니다.') }}
       {{ macros.setting_button([['all_ws_reset_db_btn','워크시트삭제']], desc='등록된 모든 워크시트를 삭제합니다.', left='시트전체삭제') }}
       {{ macros.setting_button([['all_item_reset_db_btn','모든아이템삭제']], desc='아이템 목록을 삭제합니다.', left='아이템 목록 삭제') }}
-      {{ macros.setting_button([['copied_item_reset_db_btn','복사된아이템삭제']], desc='이미 복사한 아이템 목록을 삭제합니다.', left='복사된 아이템 삭제' ) }}
-      {{ macros.setting_button([['no_item_reset_db_btn','불량아이템삭제']], desc='파일건수 0개, 사이즈 0Bytes인 아이템을 삭제합니다.', left='정보불량아이템삭제' ) }}
+      {{ macros.setting_button([['copied_item_reset_db_btn','복사된아이템삭제']], desc='이미 복사한 아이템 목록을 삭제합니다.(상태만 변경)', left='복사된 아이템 삭제' ) }}
+      {{ macros.setting_button([['no_item_reset_db_btn','불량아이템삭제']], desc='파일건수 0개, 사이즈 0Bytes인 아이템을 삭제합니다.(상태만 변경)', left='정보불량아이템삭제' ) }}
       {{ macros.setting_button([['byte_size_migration','Byte사이즈처리']], desc='임시, 문자열사이즈를 변환하여 byte단위사이즈로 DB에 기록', left='사이즈 일괄 처리' ) }}
    {{ macros.m_tab_content_end() }}
   </div><!--tab-content-->


### PR DESCRIPTION
2020-09-14: 기능개선 
 - **파일ID 처리 추가**: 폴더ID 셀의 내용이 파일ID인 경우 처리로직 추가(Gdrive API 이용 mimeType 확인)
 - 목록갱신: Thread 방식으로 변경(결과notify로 출력), 기존 데이터 비교 로직 개선(gogle sheet api limit 대응) 
 - 복사조건: 포함/제외분류에 하위분류(*) 지원 방식변경 (BlackList-WhiteList 방식에서 우선순위방식으로)
    포함우선: 포함분류에 "영화/*", 제외분류에 "영화/중국" -> 영화/중국만 제외하고 모든 영화/* 분류 받음
    제외우선: 제외분류에 "영화/*", 포함분류에 "영화/한국" -> 영화/한국만 받음 분류 받음
    포함/제외 키워드 추가: 파일유형의 아이템 목록에만 적용됨
 - 시트수정: 해당시트의 아이템 목록 삭제 기능 추가 (실제 데이터 삭제됨)

매뉴얼URL: [https://sjva.me/bbs/board.php?bo_table=manual&wr_id=1680]